### PR TITLE
feat: hover highlights and custom dropdowns for transition editing

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -24,6 +24,7 @@
   --color-state-text: #111827;
   --color-state-selected: #3b82f6;
   --color-state-accept-ring: #374151;
+  --color-state-hover-target: #a855f7;
 
   /* Transitions */
   --color-transition-stroke: #6b7280;
@@ -73,6 +74,7 @@
   --color-state-text: #e2e8f0;
   --color-state-selected: #818cf8;
   --color-state-accept-ring: #a5b4fc;
+  --color-state-hover-target: #c084fc;
 
   --color-transition-stroke: #94a3b8;
   --color-transition-text: #cbd5e1;
@@ -482,6 +484,17 @@ body {
   stroke: var(--color-state-selected);
 }
 
+/* Hover target (potential transition target while editing) */
+.is-hover-target .state-circle {
+  stroke: var(--color-state-hover-target);
+  stroke-width: 3;
+  fill: color-mix(in srgb, var(--color-state-hover-target) 15%, var(--color-state-fill));
+}
+
+.is-hover-target .accept-ring {
+  stroke: var(--color-state-hover-target);
+}
+
 /* Simulation states */
 .is-current,
 .is-accepted,
@@ -849,23 +862,6 @@ body {
   padding: 2px !important;
 }
 
-.tuple-cell-select {
-  width: 100%;
-  padding: 3px 4px;
-  border: none;
-  background: transparent;
-  color: var(--color-text-primary);
-  font-family: var(--font-mono), monospace;
-  font-size: 12px;
-  text-align: center;
-  cursor: pointer;
-  outline: none;
-}
-
-.tuple-cell-select:focus {
-  background: var(--color-input-bg);
-}
-
 .tuple-cell-multi {
   cursor: pointer;
   padding: 3px 4px;
@@ -931,8 +927,21 @@ body {
   background: var(--color-panel-border);
 }
 
-.tuple-dropdown-item input[type="checkbox"] {
-  accent-color: var(--color-button-bg);
+.tuple-dropdown-check {
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+  color: var(--color-button-bg);
+}
+
+.tuple-dropdown-item.is-checked {
+  color: var(--color-button-bg);
+  font-weight: 600;
+}
+
+.tuple-dropdown-item.is-selected {
+  color: var(--color-button-bg);
+  font-weight: 600;
 }
 
 /* --- Validation error --- */

--- a/components/canvas/StateNode.vue
+++ b/components/canvas/StateNode.vue
@@ -3,6 +3,7 @@
     class="state-node"
     :class="{
       'selected': isSelected,
+      'is-hover-target': isHoverTarget,
       'is-current': isSimCurrent,
       'is-accepted': isSimAccepted,
       'is-rejected': isSimRejected,
@@ -11,6 +12,8 @@
     :transform="`translate(${state.position.x}, ${state.position.y})`"
     style="cursor: pointer"
     @pointerdown.stop="onPointerDown"
+    @pointerenter="onPointerEnter"
+    @pointerleave="onPointerLeave"
     @click.stop
   >
     <!-- Accept state: outer ring -->
@@ -44,6 +47,7 @@ import { SimulationStatus } from "~/types/automaton";
 import { STATE_RADIUS } from "~/utils/geometry";
 import { useSelectionStore } from "~/stores/selection";
 import { useSimulationStore } from "~/stores/simulation";
+import { useHoverStore } from "~/stores/hover";
 
 const props = defineProps<{
   state: AutomatonState;
@@ -55,8 +59,13 @@ const emit = defineEmits<{
 
 const selection = useSelectionStore();
 const simulation = useSimulationStore();
+const hover = useHoverStore();
 
 const isSelected = computed(() => selection.selectedStateId === props.state.id);
+const isHoverTarget = computed(
+  () => hover.hoveredStateId === props.state.id
+    && selection.selectedStateId !== props.state.id,
+);
 const isSimCurrent = computed(
   () => simulation.status !== SimulationStatus.Idle && simulation.currentStateIds.includes(props.state.id) && simulation.status === SimulationStatus.Running,
 );
@@ -81,5 +90,15 @@ function onPointerDown(event: PointerEvent) {
   if (event.button !== 0) return;
   selection.selectState(props.state.id);
   emit("dragstart", props.state.id, event);
+}
+
+function onPointerEnter() {
+  if (selection.selectedStateId !== null && selection.selectedStateId !== props.state.id) {
+    hover.setHoveredState(props.state.id);
+  }
+}
+
+function onPointerLeave() {
+  hover.clearHoveredState();
 }
 </script>

--- a/components/editor/TargetSelect.vue
+++ b/components/editor/TargetSelect.vue
@@ -1,0 +1,188 @@
+<template>
+  <!-- Trigger button -->
+  <button
+    class="target-select-trigger mono"
+    :class="{ disabled, compact, narrow }"
+    :disabled="disabled"
+    @click="toggle"
+  >
+    <span class="target-select-label">{{ selectedLabel }}</span>
+    <svg
+      v-if="!compact"
+      class="target-select-chevron"
+      :class="{ open: isOpen }"
+      width="10"
+      height="10"
+      viewBox="0 0 10 10"
+      fill="none"
+    >
+      <path
+        d="M2.5 4L5 6.5L7.5 4"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  </button>
+
+  <!-- Backdrop -->
+  <div
+    v-if="isOpen"
+    class="tuple-dropdown-backdrop"
+    @click="close"
+  />
+
+  <!-- Dropdown list -->
+  <div
+    v-if="isOpen"
+    class="tuple-dropdown"
+    :style="{ top: dropdownY + 'px', left: dropdownX + 'px', minWidth: dropdownWidth + 'px' }"
+  >
+    <!-- Clear option -->
+    <div
+      v-if="allowClear"
+      class="tuple-dropdown-item mono"
+      :class="{ 'is-selected': !modelValue }"
+      @click="select('')"
+    >
+      -
+    </div>
+
+    <div
+      v-for="option in options"
+      :key="option.id"
+      class="tuple-dropdown-item mono"
+      :class="{ 'is-selected': option.id === modelValue }"
+      @pointerenter="hoverStore.setHoveredState(option.id)"
+      @pointerleave="hoverStore.clearHoveredState()"
+      @click="select(option.id)"
+    >
+      {{ option.name }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useHoverStore } from "~/stores/hover";
+
+const props = withDefaults(defineProps<{
+  modelValue: string;
+  options: { id: string; name: string }[];
+  disabled?: boolean;
+  placeholder?: string;
+  compact?: boolean;
+  narrow?: boolean;
+  allowClear?: boolean;
+}>(), {
+  disabled: false,
+  placeholder: "Target...",
+  compact: false,
+  narrow: false,
+  allowClear: false,
+});
+
+const emit = defineEmits<{
+  "update:modelValue": [value: string];
+}>();
+
+const hoverStore = useHoverStore();
+
+const isOpen = ref(false);
+const dropdownX = ref(0);
+const dropdownY = ref(0);
+const dropdownWidth = ref(0);
+
+const selectedLabel = computed(() => {
+  const match = props.options.find(o => o.id === props.modelValue);
+  return match?.name ?? props.placeholder;
+});
+
+function toggle(event: MouseEvent) {
+  if (props.disabled) return;
+  if (isOpen.value) {
+    close();
+    return;
+  }
+  const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+  dropdownX.value = rect.left;
+  dropdownY.value = rect.bottom + 2;
+  dropdownWidth.value = rect.width;
+  isOpen.value = true;
+}
+
+function select(id: string) {
+  emit("update:modelValue", id);
+  close();
+}
+
+function close() {
+  isOpen.value = false;
+  hoverStore.clearHoveredState();
+}
+</script>
+
+<style scoped>
+.target-select-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 4px;
+  padding: 6px 10px;
+  border: 1px solid var(--color-input-border);
+  border-radius: 6px;
+  background: var(--color-input-bg);
+  color: var(--color-text-primary);
+  font-size: 13px;
+  cursor: pointer;
+  text-align: left;
+}
+
+/* Narrow variant for transition editor rows */
+.target-select-trigger.narrow {
+  flex: 0 0 80px;
+  padding: 4px 6px;
+  font-size: 12px;
+}
+
+.target-select-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.target-select-trigger:hover:not(.disabled) {
+  border-color: var(--color-text-secondary);
+}
+
+.target-select-trigger.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Compact variant for table cells */
+.target-select-trigger.compact {
+  flex: unset;
+  width: 100%;
+  border: none;
+  border-radius: 3px;
+  background: transparent;
+  justify-content: center;
+  padding: 3px 4px;
+}
+
+.target-select-trigger.compact:hover:not(.disabled) {
+  background: var(--color-panel-border);
+  border-color: transparent;
+}
+
+.target-select-chevron {
+  flex-shrink: 0;
+  transition: transform 0.15s;
+  color: var(--color-text-secondary);
+}
+
+.target-select-chevron.open {
+  transform: rotate(180deg);
+}
+</style>

--- a/components/editor/TransitionEditor.vue
+++ b/components/editor/TransitionEditor.vue
@@ -4,19 +4,12 @@
     v-if="fixedTarget"
     class="transition-row"
   >
-    <select
-      class="select target-select"
-      :value="fixedTarget"
+    <TargetSelect
+      :model-value="fixedTarget"
+      :options="availableTargets"
+      narrow
       disabled
-    >
-      <option
-        v-for="s in availableTargets"
-        :key="s.id"
-        :value="s.id"
-      >
-        {{ s.name }}
-      </option>
-    </select>
+    />
 
     <input
       class="input input-mono symbols-input"
@@ -33,25 +26,12 @@
     v-else-if="transitions.length > 0"
     class="transition-row"
   >
-    <select
-      class="select target-select"
-      :value="transitions[0].targetId"
-      @change="onTargetChange"
-    >
-      <option
-        value=""
-        disabled
-      >
-        Target...
-      </option>
-      <option
-        v-for="s in availableTargets"
-        :key="s.id"
-        :value="s.id"
-      >
-        {{ s.name }}
-      </option>
-    </select>
+    <TargetSelect
+      :model-value="transitions[0].targetId"
+      :options="availableTargets"
+      narrow
+      @update:model-value="onTargetChange"
+    />
 
     <input
       ref="existingSymbolsRef"
@@ -97,26 +77,12 @@
     v-else
     class="transition-row"
   >
-    <select
-      class="select target-select"
-      :value="newTarget"
-      @change="onNewTargetChange"
-    >
-      <option
-        value=""
-        disabled
-        selected
-      >
-        Target...
-      </option>
-      <option
-        v-for="s in availableTargets"
-        :key="s.id"
-        :value="s.id"
-      >
-        {{ s.name }}
-      </option>
-    </select>
+    <TargetSelect
+      :model-value="newTarget"
+      :options="availableTargets"
+      narrow
+      @update:model-value="onNewTargetChange"
+    />
 
     <input
       class="input input-mono symbols-input"
@@ -216,8 +182,7 @@ function addEpsilonToExisting() {
 
 // --- NFA existing group handlers ---
 
-function onTargetChange(event: Event) {
-  const targetId = (event.target as HTMLSelectElement).value;
+function onTargetChange(targetId: string) {
   if (!targetId) return;
   for (const t of props.transitions) {
     automaton.updateTransitionTarget(t.id, targetId);
@@ -263,8 +228,8 @@ function removeGroup() {
 const newTarget = ref("");
 const newSymbols = ref("");
 
-function onNewTargetChange(event: Event) {
-  newTarget.value = (event.target as HTMLSelectElement).value;
+function onNewTargetChange(value: string) {
+  newTarget.value = value;
   tryCreateTransitions();
 }
 

--- a/components/editor/TupleBuilder.vue
+++ b/components/editor/TupleBuilder.vue
@@ -43,30 +43,13 @@
 
     <!-- q₀ (Start State) -->
     <div class="field">
-      <label
-        class="field-label"
-        for="tuple-start"
-      >q&#8320; (Start State)</label>
-      <select
-        id="tuple-start"
-        class="select"
-        :value="currentStartName"
-        @change="onStartChange"
-      >
-        <option
-          value=""
-          disabled
-        >
-          Select start state
-        </option>
-        <option
-          v-for="s in automaton.states"
-          :key="s.id"
-          :value="s.name"
-        >
-          {{ s.name }}
-        </option>
-      </select>
+      <span class="field-label">q&#8320; (Start State)</span>
+      <TargetSelect
+        :model-value="currentStartId"
+        :options="automaton.states"
+        placeholder="Select start state"
+        @update:model-value="onStartChange"
+      />
     </div>
 
     <!-- F (Accept States) -->
@@ -121,23 +104,15 @@
                 class="tuple-table-cell"
               >
                 <!-- DFA: single select -->
-                <select
+                <TargetSelect
                   v-if="automaton.type === AutomatonType.DFA"
-                  class="tuple-cell-select"
-                  :value="getDFATarget(state.id, col)"
-                  @change="setDFATransition(state.id, col, ($event.target as HTMLSelectElement).value)"
-                >
-                  <option value="">
-                    -
-                  </option>
-                  <option
-                    v-for="t in automaton.states"
-                    :key="t.id"
-                    :value="t.id"
-                  >
-                    {{ t.name }}
-                  </option>
-                </select>
+                  :model-value="getDFATarget(state.id, col)"
+                  :options="automaton.states"
+                  placeholder="-"
+                  compact
+                  allow-clear
+                  @update:model-value="(val: string) => setDFATransition(state.id, col, val)"
+                />
                 <!-- NFA: multi-select dropdown -->
                 <div
                   v-else
@@ -166,18 +141,33 @@
       class="tuple-dropdown"
       :style="{ top: dropdown.y + 'px', left: dropdown.x + 'px' }"
     >
-      <label
+      <div
         v-for="s in automaton.states"
         :key="s.id"
         class="tuple-dropdown-item"
+        :class="{ 'is-checked': hasNFATarget(dropdown.sourceId, dropdown.symbol, s.id) }"
+        @pointerenter="hoverStore.setHoveredState(s.id)"
+        @pointerleave="hoverStore.clearHoveredState()"
+        @click="toggleNFATarget(dropdown.sourceId, dropdown.symbol, s.id)"
       >
-        <input
-          type="checkbox"
-          :checked="hasNFATarget(dropdown.sourceId, dropdown.symbol, s.id)"
-          @change="toggleNFATarget(dropdown.sourceId, dropdown.symbol, s.id)"
+        <svg
+          class="tuple-dropdown-check"
+          width="14"
+          height="14"
+          viewBox="0 0 14 14"
+          fill="none"
         >
+          <path
+            v-if="hasNFATarget(dropdown.sourceId, dropdown.symbol, s.id)"
+            d="M3 7l3 3 5-5"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
         <span class="mono">{{ s.name }}</span>
-      </label>
+      </div>
     </div>
 
     <!-- Re-layout button -->
@@ -192,6 +182,7 @@
 
 <script setup lang="ts">
 import { useAutomatonStore } from "~/stores/automaton";
+import { useHoverStore } from "~/stores/hover";
 import { useSimulationStore } from "~/stores/simulation";
 import { useViewportStore } from "~/stores/viewport";
 import { AutomatonType, EPSILON } from "~/types/automaton";
@@ -200,6 +191,7 @@ import type { LayoutTransition } from "~/utils/layout";
 import { buildVisualInfosFromStore, resolveCollisions } from "~/utils/collision";
 
 const automaton = useAutomatonStore();
+const hoverStore = useHoverStore();
 const simulation = useSimulationStore();
 const viewport = useViewportStore();
 
@@ -276,15 +268,13 @@ function syncStatesFromInput() {
 
 // --- Start state ---
 
-const currentStartName = computed(() => {
-  return automaton.startState?.name ?? "";
+const currentStartId = computed(() => {
+  return automaton.startState?.id ?? "";
 });
 
-function onStartChange(event: Event) {
-  const name = (event.target as HTMLSelectElement).value;
-  const state = automaton.states.find(s => s.name === name);
-  if (state) {
-    automaton.setStartState(state.id);
+function onStartChange(id: string) {
+  if (id) {
+    automaton.setStartState(id);
   }
 }
 
@@ -379,6 +369,7 @@ function openDropdown(sourceId: string, symbol: string, event: MouseEvent) {
 
 function closeDropdown() {
   dropdown.value.open = false;
+  hoverStore.clearHoveredState();
 }
 
 // --- Re-layout ---

--- a/stores/hover.ts
+++ b/stores/hover.ts
@@ -1,0 +1,32 @@
+import { defineStore } from "pinia";
+
+/** Internal state for the hover store. */
+interface HoverState {
+  /** ID of the state node currently being hovered, or null if none. */
+  hoveredStateId: string | null;
+}
+
+/**
+ * Tracks which state node is currently hovered on the canvas.
+ * Used to highlight potential transition targets when editing a selected state.
+ */
+export const useHoverStore = defineStore("hover", {
+  state: (): HoverState => ({
+    hoveredStateId: null,
+  }),
+
+  actions: {
+    /**
+     * Set the currently hovered state.
+     * @param id - ID of the state being hovered.
+     */
+    setHoveredState(id: string) {
+      this.hoveredStateId = id;
+    },
+
+    /** Clear the hovered state. */
+    clearHoveredState() {
+      this.hoveredStateId = null;
+    },
+  },
+});

--- a/stores/selection.ts
+++ b/stores/selection.ts
@@ -1,4 +1,5 @@
 import { defineStore } from "pinia";
+import { useHoverStore } from "~/stores/hover";
 
 /** Internal state for the selection store. */
 interface SelectionState {
@@ -26,12 +27,14 @@ export const useSelectionStore = defineStore("selection", {
     selectState(id: string) {
       this.selectedStateId = id;
       this.selectedTransitionId = null;
+      useHoverStore().clearHoveredState();
     },
 
     /** Clear all selections, returning to the default (nothing selected) state. */
     clearSelection() {
       this.selectedStateId = null;
       this.selectedTransitionId = null;
+      useHoverStore().clearHoveredState();
     },
   },
 });


### PR DESCRIPTION
## Summary

Closes #8

- **Hover store** (`stores/hover.ts`): tracks which state is hovered, used by canvas nodes and sidebar dropdowns
- **TargetSelect component** (`components/editor/TargetSelect.vue`): custom single-select dropdown replacing all native `<select>` elements in sidebar editors. Supports `narrow`, `compact`, and `allowClear` variants
- **Canvas hover highlight**: hovering a state option in any dropdown highlights the corresponding node on the canvas with a purple tinted fill and solid stroke
- **NFA dropdown restyle**: replaced native checkboxes with themed checkmark SVGs in the TupleBuilder NFA multi-select dropdown
- **Selection store integration**: clears hover state on selection change to prevent stale highlights

### Dropdowns replaced
| Location | Before | After |
|----------|--------|-------|
| TransitionEditor (3 selects) | Native `<select>` | `<TargetSelect narrow>` |
| TupleBuilder start state | Native `<select>` | `<TargetSelect>` |
| TupleBuilder DFA table cells | Native `<select>` | `<TargetSelect compact allowClear>` |
| TupleBuilder NFA table cells | Custom div + native checkbox | Custom div + SVG checkmark |

## Test plan

- [ ] Select a state → open transition target dropdown → hover options → canvas states highlight purple
- [ ] Open TupleBuilder start state dropdown → hover options → canvas states highlight
- [ ] Open DFA transition table cell dropdown → hover options → canvas states highlight
- [ ] Open NFA transition table cell dropdown → hover checkmark items → canvas states highlight
- [ ] Click an option → dropdown closes, hover clears
- [ ] Click outside dropdown (backdrop) → closes, hover clears
- [ ] DFA fixed-target shows as disabled (no dropdown opens)
- [ ] Light and dark mode both render correctly
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)