### PR TITLE
feat: widen state bubble and add resize for long names

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -582,9 +582,11 @@ body {
   flex-direction: column;
   gap: 10px;
   box-shadow: var(--shadow-md);
-  min-width: 220px;
-  max-width: 320px;
+  min-width: 260px;
+  max-width: 600px;
   cursor: default;
+  resize: horizontal;
+  overflow: hidden;
 }
 
 /* Drag header */
@@ -719,13 +721,15 @@ body {
 }
 
 .target-select {
-  flex: 0 0 80px;
+  flex: 0 1 auto;
+  min-width: 60px;
   font-size: 12px;
   padding: 4px 6px;
 }
 
 .target-label {
-  flex: 0 0 80px;
+  flex: 0 1 auto;
+  min-width: 60px;
   font-size: 12px;
   padding: 4px 6px;
   color: var(--color-text-secondary);

--- a/components/editor/TargetSelect.vue
+++ b/components/editor/TargetSelect.vue
@@ -140,7 +140,8 @@ function close() {
 
 /* Narrow variant for transition editor rows */
 .target-select-trigger.narrow {
-  flex: 0 0 80px;
+  flex: 0 1 auto;
+  min-width: 60px;
   padding: 4px 6px;
   font-size: 12px;
 }


### PR DESCRIPTION
## Summary
- Increases bubble max-width from 320px to 600px for set-notation state names (e.g., `{q0,q1,q2,q3}`)
- Adds `resize: horizontal` so users can manually drag the bubble wider/narrower
- Target labels and selects now use flexible widths (`flex: 0 1 auto`) instead of fixed 80px to prevent truncation

## Test plan
- [ ] Open an NFA with long state names (or convert one via NFA→DFA)
- [ ] Verify the bubble is wide enough to display full state names
- [ ] Drag the resize handle on the bottom-right corner of the bubble to resize horizontally
- [ ] Verify target state labels in the transition editor are not truncated

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)