### PR TITLE
fix: make alphabet field editable in tuple builder

### DIFF
--- a/components/canvas/StateBubble.vue
+++ b/components/canvas/StateBubble.vue
@@ -314,12 +314,10 @@ function onAlphabetKeydown(e: KeyboardEvent) {
     commitAlphabet();
     return;
   }
-  if (e.key !== ",") return;
-  e.preventDefault();
-  const input = e.target as HTMLInputElement;
-  alphabetInput.value = input.value + ",";
-  input.value = alphabetInput.value;
-  commitAlphabet();
+  if (e.key === ",") {
+    isEditingAlphabet.value = true;
+    commitAlphabet();
+  }
 }
 
 function commitAlphabet() {

--- a/components/editor/TupleBuilder.vue
+++ b/components/editor/TupleBuilder.vue
@@ -33,12 +33,17 @@
       >
     </div>
 
-    <!-- Σ (Alphabet) — read-only, derived from transitions -->
+    <!-- Σ (Alphabet) -->
     <div class="field">
       <span class="field-label">&Sigma; (Alphabet)</span>
-      <div class="input input-mono tuple-readonly">
-        {{ automaton.alphabet.length > 0 ? automaton.alphabet.join(', ') : '(empty)' }}
-      </div>
+      <input
+        id="tuple-alphabet"
+        v-model="alphabetInput"
+        class="input input-mono"
+        placeholder="a, b, c"
+        @blur="syncAlphabetFromInput"
+        @keydown="onAlphabetKeydown"
+      >
     </div>
 
     <!-- q₀ (Start State) -->
@@ -264,6 +269,54 @@ function syncStatesFromInput() {
 
   // Update the input to reflect actual store state
   statesInput.value = automaton.states.map(s => s.name).join(", ");
+}
+
+// --- Alphabet sync ---
+
+const alphabetInput = ref(automaton.alphabet.join(", "));
+
+watch(
+  () => automaton.alphabet.join(", "),
+  (val) => {
+    if (document.activeElement?.id !== "tuple-alphabet") {
+      alphabetInput.value = val;
+    }
+  },
+);
+
+function syncAlphabetFromInput() {
+  const newSymbols = alphabetInput.value
+    .split(",")
+    .map(s => s.trim())
+    .filter(s => s.length > 0);
+
+  const removedSymbols = automaton.alphabet.filter(s => !newSymbols.includes(s));
+  const affectedTransitions = automaton.transitions.filter(
+    t => removedSymbols.includes(t.symbol),
+  );
+
+  if (affectedTransitions.length > 0) {
+    const count = affectedTransitions.length;
+    const syms = removedSymbols.join(", ");
+    if (!confirm(`Remove symbol(s) '${syms}'? This will delete ${count} transition(s).`)) {
+      alphabetInput.value = automaton.alphabet.join(", ");
+      return;
+    }
+  }
+
+  automaton.setAlphabet(newSymbols);
+  alphabetInput.value = automaton.alphabet.join(", ");
+}
+
+function onAlphabetKeydown(e: KeyboardEvent) {
+  if (e.key === "Enter") {
+    e.preventDefault();
+    syncAlphabetFromInput();
+    return;
+  }
+  if (e.key === ",") {
+    syncAlphabetFromInput();
+  }
 }
 
 // --- Start state ---


### PR DESCRIPTION
## Summary

- Replace the read-only alphabet display in the 5-tuple builder with an editable text input
- Same commit-on-blur/comma/enter behavior as the state bubble alphabet field
- Confirmation dialog when removing symbols that have existing transitions
- Fix comma keydown handling in both tuple builder and state bubble to let the comma through naturally

Closes #33

## Test plan

- [x] 233 tests pass
- [x] Type-check clean
- [x] ESLint clean
- [x] Manual QA: edit alphabet in tuple builder, verify grid columns update
- [x] Manual QA: remove symbol with transitions, verify confirmation dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)