### PR TITLE
feat: add canvas toolbar with zoom controls, fit-to-content, and fullscreen

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -432,6 +432,7 @@ body {
    ======================================== */
 
 .svg-canvas-wrapper {
+  position: relative;
   width: 100%;
   height: 100%;
   outline: none;
@@ -447,6 +448,84 @@ body {
   width: 100%;
   height: 100%;
   display: block;
+}
+
+/* ========================================
+   Canvas Toolbar
+   ======================================== */
+
+.canvas-toolbar {
+  position: absolute;
+  bottom: 12px;
+  right: 12px;
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 4px;
+  background: var(--color-panel-bg);
+  border: 1px solid var(--color-panel-border);
+  border-radius: 8px;
+  box-shadow: var(--shadow-md);
+}
+
+.toolbar-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: color 0.15s, background-color 0.15s;
+  flex-shrink: 0;
+}
+
+.toolbar-btn:hover:not(:disabled) {
+  color: var(--color-text-primary);
+  background: var(--color-panel-border);
+}
+
+.toolbar-btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.toolbar-btn.active {
+  color: var(--color-button-bg);
+}
+
+.toolbar-zoom-label {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  height: 28px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--color-text-secondary);
+  font-family: var(--font-mono), monospace;
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: color 0.15s, background-color 0.15s;
+}
+
+.toolbar-zoom-label:hover {
+  color: var(--color-text-primary);
+  background: var(--color-panel-border);
+}
+
+.toolbar-separator {
+  width: 1px;
+  height: 16px;
+  background: var(--color-panel-border);
+  margin: 0 2px;
+  flex-shrink: 0;
 }
 
 /* ========================================

--- a/components/canvas/CanvasToolbar.vue
+++ b/components/canvas/CanvasToolbar.vue
@@ -1,0 +1,153 @@
+<template>
+  <div
+    class="canvas-toolbar"
+    @pointerdown.stop
+  >
+    <!-- Zoom out -->
+    <button
+      class="toolbar-btn"
+      title="Zoom out"
+      :disabled="zoom <= MIN_ZOOM"
+      @click="$emit('zoom-out')"
+    >
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 14 14"
+        fill="none"
+      >
+        <path
+          d="M3 7h8"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+        />
+      </svg>
+    </button>
+
+    <!-- Zoom label (click to reset) -->
+    <button
+      class="toolbar-zoom-label"
+      title="Reset zoom to 100%"
+      @click="$emit('reset-zoom')"
+    >
+      {{ zoomLabel }}
+    </button>
+
+    <!-- Zoom in -->
+    <button
+      class="toolbar-btn"
+      title="Zoom in"
+      :disabled="zoom >= MAX_ZOOM"
+      @click="$emit('zoom-in')"
+    >
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 14 14"
+        fill="none"
+      >
+        <path
+          d="M7 3v8M3 7h8"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+        />
+      </svg>
+    </button>
+
+    <div class="toolbar-separator" />
+
+    <!-- Fit to content -->
+    <button
+      class="toolbar-btn"
+      title="Fit to content"
+      @click="$emit('fit-to-content')"
+    >
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 14 14"
+        fill="none"
+      >
+        <path
+          d="M1.5 5V2.5a1 1 0 0 1 1-1H5M9 1.5h2.5a1 1 0 0 1 1 1V5M12.5 9v2.5a1 1 0 0 1-1 1H9M5 12.5H2.5a1 1 0 0 1-1-1V9"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+    </button>
+
+    <!-- Fullscreen toggle -->
+    <button
+      class="toolbar-btn"
+      :class="{ active: isFullscreen }"
+      :title="isFullscreen ? 'Exit fullscreen' : 'Fullscreen'"
+      @click="$emit('toggle-fullscreen')"
+    >
+      <svg
+        v-if="!isFullscreen"
+        width="14"
+        height="14"
+        viewBox="0 0 14 14"
+        fill="none"
+      >
+        <path
+          d="M8.5 1.5H12.5V5.5M5.5 12.5H1.5V8.5"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+        <path
+          d="M12.5 1.5L8 6M1.5 12.5L6 8"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+        />
+      </svg>
+      <svg
+        v-else
+        width="14"
+        height="14"
+        viewBox="0 0 14 14"
+        fill="none"
+      >
+        <path
+          d="M12.5 5.5H8.5V1.5M1.5 8.5H5.5V12.5"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+        <path
+          d="M8.5 5.5L13 1M5.5 8.5L1 13"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+        />
+      </svg>
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { MIN_ZOOM, MAX_ZOOM } from "~/composables/useCanvasInteraction";
+
+const props = defineProps<{
+  zoom: number;
+  isFullscreen: boolean;
+}>();
+
+defineEmits<{
+  "zoom-in": [];
+  "zoom-out": [];
+  "reset-zoom": [];
+  "fit-to-content": [];
+  "toggle-fullscreen": [];
+}>();
+
+const zoomLabel = computed(() => `${Math.round(props.zoom * 100)}%`);
+</script>

--- a/components/canvas/SvgCanvas.vue
+++ b/components/canvas/SvgCanvas.vue
@@ -130,6 +130,16 @@
       :is-dragging="isDragging"
       :zoom="zoom"
     />
+
+    <CanvasToolbar
+      :zoom="zoom"
+      :is-fullscreen="viewport.isFullscreen"
+      @zoom-in="zoomIn"
+      @zoom-out="zoomOut"
+      @reset-zoom="resetZoom"
+      @fit-to-content="onFitToContent"
+      @toggle-fullscreen="viewport.toggleFullscreen()"
+    />
   </div>
 </template>
 
@@ -160,7 +170,7 @@ const transitionGroups = computed(() => {
 });
 
 const svgRef = ref<SVGSVGElement | null>(null);
-const { viewBox, screenToWorld, worldToScreen, zoom, onWheel, onPanStart, onPanMove, onPanEnd, fitToContent }
+const { viewBox, screenToWorld, worldToScreen, zoom, onWheel, onPanStart, onPanMove, onPanEnd, fitToContent, zoomIn, zoomOut, resetZoom }
   = useCanvasInteraction(svgRef);
 const { isDragging, dragTargetId, hasDragged, onDragStart, onDragMove, onDragEnd } = useDragState(screenToWorld);
 
@@ -227,15 +237,41 @@ function onStateDragStart(stateId: string, event: PointerEvent) {
   onDragStart(stateId, event);
 }
 
+/** Fit the viewport to show all states with padding. */
+function onFitToContent() {
+  if (automaton.states.length === 0) return;
+  const visualInfos = buildVisualInfosFromStore(automaton.states, automaton.transitions);
+  fitToContent(visualInfos);
+}
+
 onMounted(() => document.addEventListener("keydown", onKeyDown));
 onUnmounted(() => document.removeEventListener("keydown", onKeyDown));
 
 function onKeyDown(event: KeyboardEvent) {
   const tag = (event.target as HTMLElement)?.tagName;
+  const mod = event.metaKey || event.ctrlKey;
 
   if (event.key === "Escape") {
+    if (viewport.isFullscreen) {
+      viewport.exitFullscreen();
+      return;
+    }
     selection.closeAll();
     (event.target as HTMLElement)?.blur();
+    return;
+  }
+
+  // Ctrl/Cmd+0 — reset zoom (works even with input focused)
+  if (mod && event.key === "0") {
+    event.preventDefault();
+    resetZoom();
+    return;
+  }
+
+  // Ctrl/Cmd+Shift+F — toggle fullscreen
+  if (mod && event.shiftKey && event.key.toLowerCase() === "f") {
+    event.preventDefault();
+    viewport.toggleFullscreen();
     return;
   }
 

--- a/composables/useCanvasInteraction.ts
+++ b/composables/useCanvasInteraction.ts
@@ -4,11 +4,13 @@ import type { StateVisualInfo } from "~/utils/collision";
 import { computeStateBounds } from "~/utils/collision";
 
 /** Minimum zoom level (fully zoomed out). */
-const MIN_ZOOM = 0.2;
+export const MIN_ZOOM = 0.2;
 /** Maximum zoom level (fully zoomed in). */
-const MAX_ZOOM = 5;
+export const MAX_ZOOM = 5;
 /** Multiplier applied to wheel deltaY to control zoom speed. */
 const ZOOM_SENSITIVITY = 0.001;
+/** Multiplier per zoom button click (industry standard — Figma, Google Maps). */
+const ZOOM_STEP = 1.25;
 
 /**
  * Composable for SVG canvas pan and zoom interaction.
@@ -169,6 +171,43 @@ export function useCanvasInteraction(svgRef: Ref<SVGSVGElement | null>) {
     pan.y = centerY - (rect.height / zoom.value) / 2;
   }
 
+  /**
+   * Zoom to a target level, keeping the viewport center fixed in world space.
+   * Used by button-based zoom (unlike wheel zoom which centers on cursor).
+   */
+  function zoomToCenter(targetZoom: number) {
+    const svgEl = svgRef.value;
+    if (!svgEl) return;
+
+    const clamped = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, targetZoom));
+    const rect = svgEl.getBoundingClientRect();
+
+    // Current viewport center in world coords
+    const centerX = pan.x + (rect.width / zoom.value) / 2;
+    const centerY = pan.y + (rect.height / zoom.value) / 2;
+
+    zoom.value = clamped;
+
+    // Adjust pan so the same world point stays at viewport center
+    pan.x = centerX - (rect.width / clamped) / 2;
+    pan.y = centerY - (rect.height / clamped) / 2;
+  }
+
+  /** Zoom in by one step (1.25x). */
+  function zoomIn() {
+    zoomToCenter(zoom.value * ZOOM_STEP);
+  }
+
+  /** Zoom out by one step (÷1.25). */
+  function zoomOut() {
+    zoomToCenter(zoom.value / ZOOM_STEP);
+  }
+
+  /** Reset zoom to 100%. */
+  function resetZoom() {
+    zoomToCenter(1);
+  }
+
   return {
     pan,
     zoom,
@@ -181,5 +220,8 @@ export function useCanvasInteraction(svgRef: Ref<SVGSVGElement | null>) {
     onPanMove,
     onPanEnd,
     fitToContent,
+    zoomIn,
+    zoomOut,
+    resetZoom,
   };
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,10 +2,12 @@
   <div class="workspace">
     <SvgCanvas class="canvas-area" />
     <div
+      v-show="!viewport.isFullscreen"
       class="resize-handle"
       @pointerdown="onPointerDown"
     />
     <aside
+      v-show="!viewport.isFullscreen"
       class="side-panel"
       :style="{ width: panelWidth + 'px' }"
     >
@@ -41,10 +43,12 @@
 import { ref } from "vue";
 import { useAutomatonStore } from "~/stores/automaton";
 import { useSimulationStore } from "~/stores/simulation";
+import { useViewportStore } from "~/stores/viewport";
 import { AutomatonType } from "~/types/automaton";
 
 const automaton = useAutomatonStore();
 const simulation = useSimulationStore();
+const viewport = useViewportStore();
 
 function setType(type: AutomatonType) {
   if (automaton.type === type) return;

--- a/stores/__tests__/viewport.test.ts
+++ b/stores/__tests__/viewport.test.ts
@@ -19,4 +19,32 @@ describe("stores/viewport", () => {
     store.requestFitToContent();
     expect(store.fitRequestId).toBe(2);
   });
+
+  it("starts with isFullscreen as false", () => {
+    const store = useViewportStore();
+    expect(store.isFullscreen).toBe(false);
+  });
+
+  it("toggleFullscreen flips the boolean", () => {
+    const store = useViewportStore();
+    store.toggleFullscreen();
+    expect(store.isFullscreen).toBe(true);
+    store.toggleFullscreen();
+    expect(store.isFullscreen).toBe(false);
+  });
+
+  it("exitFullscreen sets to false", () => {
+    const store = useViewportStore();
+    store.toggleFullscreen();
+    expect(store.isFullscreen).toBe(true);
+    store.exitFullscreen();
+    expect(store.isFullscreen).toBe(false);
+  });
+
+  it("exitFullscreen is a no-op when already false", () => {
+    const store = useViewportStore();
+    expect(store.isFullscreen).toBe(false);
+    store.exitFullscreen();
+    expect(store.isFullscreen).toBe(false);
+  });
 });

--- a/stores/viewport.ts
+++ b/stores/viewport.ts
@@ -12,12 +12,22 @@ export const useViewportStore = defineStore("viewport", {
   state: () => ({
     /** Monotonically increasing counter; each increment triggers a fit-to-content. */
     fitRequestId: 0,
+    /** Whether the canvas is in fullscreen mode (side panel hidden). */
+    isFullscreen: false,
   }),
 
   actions: {
     /** Signal that the canvas should re-center and zoom to fit all content. */
     requestFitToContent() {
       this.fitRequestId++;
+    },
+    /** Toggle fullscreen mode on or off. */
+    toggleFullscreen() {
+      this.isFullscreen = !this.isFullscreen;
+    },
+    /** Exit fullscreen mode (no-op if already not fullscreen). */
+    exitFullscreen() {
+      this.isFullscreen = false;
     },
   },
 });


### PR DESCRIPTION
## Summary

- Add floating canvas toolbar with zoom in/out (1.25x step), zoom percentage label (click to reset to 100%), fit-to-content, and fullscreen toggle
- Fullscreen mode hides side panel and resize handle via `v-show` (CSS-based, not browser Fullscreen API)
- Keyboard shortcuts: `Ctrl+0` resets zoom, `Ctrl+Shift+F` toggles fullscreen, `Escape` exits fullscreen

Closes #44

## Test plan

- [ ] Zoom in/out buttons work, disabled at min/max zoom
- [ ] Zoom label shows correct percentage, click resets to 100%
- [ ] Fit-to-content centers all states in viewport
- [ ] Fullscreen hides side panel, Escape exits, Ctrl+Shift+F toggles
- [ ] Ctrl+0 resets zoom (works even with input focused)
- [ ] Toolbar respects light/dark theme
- [ ] `npm run test` passes (320 tests including 4 new viewport tests)
- [ ] `npx tsc --noEmit` clean
- [ ] `npx eslint .` clean