### PR TITLE
feat: preserve viewport in JSON export and add native save dialog (#19, #24)

### DIFF
--- a/components/canvas/SvgCanvas.vue
+++ b/components/canvas/SvgCanvas.vue
@@ -170,7 +170,7 @@ const transitionGroups = computed(() => {
 });
 
 const svgRef = ref<SVGSVGElement | null>(null);
-const { viewBox, screenToWorld, worldToScreen, zoom, onWheel, onPanStart, onPanMove, onPanEnd, fitToContent, zoomIn, zoomOut, resetZoom }
+const { pan, viewBox, screenToWorld, worldToScreen, zoom, onWheel, onPanStart, onPanMove, onPanEnd, fitToContent, zoomIn, zoomOut, resetZoom }
   = useCanvasInteraction(svgRef);
 const { isDragging, dragTargetId, hasDragged, onDragStart, onDragMove, onDragEnd } = useDragState(screenToWorld);
 
@@ -183,6 +183,22 @@ const visibleBubbleStates = computed(() => {
   return [...ids]
     .map(id => automaton.getState(id))
     .filter((s): s is AutomatonState => s != null);
+});
+
+// Sync composable pan/zoom → viewport store (for export access)
+watch(
+  () => [pan.x, pan.y, zoom.value] as const,
+  ([x, y, z]) => {
+    viewport.syncViewport(x, y, z);
+  },
+  { immediate: true },
+);
+
+// Apply viewport from import (triggered by viewportRestoreId)
+watch(() => viewport.viewportRestoreId, () => {
+  pan.x = viewport.panX;
+  pan.y = viewport.panY;
+  zoom.value = viewport.zoom;
 });
 
 // Fit-to-content when signaled by the viewport store (e.g. after build/relayout)

--- a/components/ui/AppHeader.vue
+++ b/components/ui/AppHeader.vue
@@ -129,12 +129,14 @@
 import { useAutomatonStore } from "~/stores/automaton";
 import { useSelectionStore } from "~/stores/selection";
 import { useSimulationStore } from "~/stores/simulation";
-import { exportSvgBlob, exportRasterBlob, triggerDownload } from "~/utils/export";
+import { useViewportStore } from "~/stores/viewport";
+import { exportSvgBlob, exportRasterBlob, saveBlob } from "~/utils/export";
 import type { AutomatonExport } from "~/types/automaton";
 
 const automaton = useAutomatonStore();
 const selection = useSelectionStore();
 const simulation = useSimulationStore();
+const viewport = useViewportStore();
 
 const fileInput = ref<HTMLInputElement | null>(null);
 const exportMenuOpen = ref(false);
@@ -164,9 +166,14 @@ function getPositions() {
 function onExportJSON() {
   exportMenuOpen.value = false;
   const data = automaton.exportJSON();
+  data.viewport = {
+    panX: viewport.panX,
+    panY: viewport.panY,
+    zoom: viewport.zoom,
+  };
   const json = JSON.stringify(data, null, 2);
   const blob = new Blob([json], { type: "application/json" });
-  triggerDownload(blob, `${sanitizedName()}.json`);
+  saveBlob(blob, `${sanitizedName()}.json`, { "application/json": [".json"] });
 }
 
 function onExportSVG() {
@@ -175,7 +182,7 @@ function onExportSVG() {
   if (!svg) return;
   const blob = exportSvgBlob(svg, getPositions());
   if (!blob) return;
-  triggerDownload(blob, `${sanitizedName()}.svg`);
+  saveBlob(blob, `${sanitizedName()}.svg`, { "image/svg+xml": [".svg"] });
 }
 
 async function onExportPNG() {
@@ -184,7 +191,7 @@ async function onExportPNG() {
   if (!svg) return;
   const blob = await exportRasterBlob(svg, getPositions(), "png");
   if (!blob) return;
-  triggerDownload(blob, `${sanitizedName()}.png`);
+  saveBlob(blob, `${sanitizedName()}.png`, { "image/png": [".png"] });
 }
 
 async function onExportJPEG() {
@@ -193,7 +200,7 @@ async function onExportJPEG() {
   if (!svg) return;
   const blob = await exportRasterBlob(svg, getPositions(), "jpeg");
   if (!blob) return;
-  triggerDownload(blob, `${sanitizedName()}.jpeg`);
+  saveBlob(blob, `${sanitizedName()}.jpeg`, { "image/jpeg": [".jpeg", ".jpg"] });
 }
 
 function triggerImport() {
@@ -210,6 +217,15 @@ async function onImport(event: Event) {
     selection.clearSelection();
     simulation.setInput("");
     automaton.importJSON(data);
+
+    // Restore viewport if present, otherwise fit-to-content
+    if (data.viewport) {
+      viewport.syncViewport(data.viewport.panX, data.viewport.panY, data.viewport.zoom);
+      viewport.requestViewportRestore();
+    }
+    else {
+      viewport.requestFitToContent();
+    }
   }
   catch (e) {
     console.error("Failed to import automaton:", e);

--- a/stores/__tests__/viewport.test.ts
+++ b/stores/__tests__/viewport.test.ts
@@ -47,4 +47,32 @@ describe("stores/viewport", () => {
     store.exitFullscreen();
     expect(store.isFullscreen).toBe(false);
   });
+
+  it("starts with default viewport values", () => {
+    const store = useViewportStore();
+    expect(store.panX).toBe(0);
+    expect(store.panY).toBe(0);
+    expect(store.zoom).toBe(1);
+  });
+
+  it("syncViewport updates pan and zoom", () => {
+    const store = useViewportStore();
+    store.syncViewport(-200, -150, 1.5);
+    expect(store.panX).toBe(-200);
+    expect(store.panY).toBe(-150);
+    expect(store.zoom).toBe(1.5);
+  });
+
+  it("starts with viewportRestoreId at 0", () => {
+    const store = useViewportStore();
+    expect(store.viewportRestoreId).toBe(0);
+  });
+
+  it("requestViewportRestore increments the counter", () => {
+    const store = useViewportStore();
+    store.requestViewportRestore();
+    expect(store.viewportRestoreId).toBe(1);
+    store.requestViewportRestore();
+    expect(store.viewportRestoreId).toBe(2);
+  });
 });

--- a/stores/viewport.ts
+++ b/stores/viewport.ts
@@ -14,6 +14,14 @@ export const useViewportStore = defineStore("viewport", {
     fitRequestId: 0,
     /** Whether the canvas is in fullscreen mode (side panel hidden). */
     isFullscreen: false,
+    /** Current pan X offset in world coordinates (synced from canvas composable). */
+    panX: 0,
+    /** Current pan Y offset in world coordinates (synced from canvas composable). */
+    panY: 0,
+    /** Current zoom level (synced from canvas composable). */
+    zoom: 1,
+    /** Monotonically increasing counter; each increment triggers a viewport restore. */
+    viewportRestoreId: 0,
   }),
 
   actions: {
@@ -28,6 +36,16 @@ export const useViewportStore = defineStore("viewport", {
     /** Exit fullscreen mode (no-op if already not fullscreen). */
     exitFullscreen() {
       this.isFullscreen = false;
+    },
+    /** Sync the viewport pan/zoom from the canvas composable. */
+    syncViewport(panX: number, panY: number, zoom: number) {
+      this.panX = panX;
+      this.panY = panY;
+      this.zoom = zoom;
+    },
+    /** Signal that imported viewport data should be applied to the canvas. */
+    requestViewportRestore() {
+      this.viewportRestoreId++;
     },
   },
 });

--- a/types/automaton.ts
+++ b/types/automaton.ts
@@ -96,10 +96,22 @@ export interface SimulationState {
   history: SimulationHistoryEntry[];
 }
 
+/** Viewport state (pan/zoom) for preserving the user's view across export/import. */
+export interface ViewportData {
+  /** Horizontal pan offset in world coordinates. */
+  panX: number;
+  /** Vertical pan offset in world coordinates. */
+  panY: number;
+  /** Zoom factor (1 = 100%). */
+  zoom: number;
+}
+
 /** Versioned wrapper for JSON import/export of an automaton. */
 export interface AutomatonExport {
   /** Schema version for forward compatibility. Currently always 1. */
   version: 1;
   /** The serialized automaton data. */
   automaton: Automaton;
+  /** Optional viewport state. Missing in exports from older versions. */
+  viewport?: ViewportData;
 }

--- a/utils/export.ts
+++ b/utils/export.ts
@@ -1,5 +1,16 @@
 import type { Position } from "~/types/automaton";
 
+/** Minimal type for the File System Access API (Chromium only, not in all TS libs). */
+interface FileSystemAccessGlobal {
+  showSaveFilePicker: (options?: Record<string, unknown>) => Promise<{
+    getParent?: () => Promise<FileSystemDirectoryHandle>;
+    createWritable: () => Promise<{
+      write: (data: Blob) => Promise<void>;
+      close: () => Promise<void>;
+    }>;
+  }>;
+}
+
 interface Bounds {
   x: number;
   y: number;
@@ -202,12 +213,66 @@ export async function exportRasterBlob(
 
 /**
  * Trigger a browser download for a Blob with the given filename.
+ * Used as fallback when the File System Access API is unavailable.
  */
-export function triggerDownload(blob: Blob, filename: string): void {
+function triggerDownload(blob: Blob, filename: string): void {
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
   a.download = filename;
   a.click();
   URL.revokeObjectURL(url);
+}
+
+/** Cached directory handle for File System Access API (session-only, Chromium). */
+let lastDirectoryHandle: FileSystemDirectoryHandle | null = null;
+
+/**
+ * Save a Blob using the File System Access API (native save dialog) when available,
+ * falling back to blob+anchor download for unsupported browsers.
+ *
+ * In Chromium, caches the parent directory handle so subsequent exports
+ * in the same session default to the same folder.
+ *
+ * @param blob     - The file content to save.
+ * @param filename - Suggested filename (used in both native dialog and fallback).
+ * @param accept   - Optional MIME type filter for the save dialog.
+ */
+export async function saveBlob(
+  blob: Blob,
+  filename: string,
+  accept?: Record<string, string[]>,
+): Promise<void> {
+  if ("showSaveFilePicker" in globalThis) {
+    try {
+      const options: Record<string, unknown> = {
+        suggestedName: filename,
+      };
+      if (accept) {
+        options.types = [{ accept }];
+      }
+      if (lastDirectoryHandle) {
+        options.startIn = lastDirectoryHandle;
+      }
+
+      const handle = await (globalThis as unknown as FileSystemAccessGlobal).showSaveFilePicker(options);
+
+      // Cache parent directory for next export
+      if (typeof handle.getParent === "function") {
+        lastDirectoryHandle = await handle.getParent();
+      }
+
+      const writable = await handle.createWritable();
+      await writable.write(blob);
+      await writable.close();
+      return;
+    }
+    catch {
+      // User cancelled the dialog — do nothing
+      return;
+    }
+  }
+
+  // Fallback for Firefox/Safari
+  triggerDownload(blob, filename);
 }


### PR DESCRIPTION
## Summary
- **#19**: JSON exports now include an optional `viewport` field (panX, panY, zoom). On import, the viewport is restored to the saved position. Old exports without viewport data trigger fit-to-content instead.
- **#24**: All export formats (JSON, SVG, PNG, JPEG) now use the File System Access API for a native save dialog with prefilled filename and per-session directory caching (Chromium). Firefox/Safari fall back to the standard browser download with suggested filename.

## Test plan
- [ ] Export JSON → verify file contains `viewport` field with panX, panY, zoom
- [ ] Import that JSON → viewport restores to the saved position
- [ ] Import old JSON (no viewport field) → fit-to-content fires
- [ ] Export SVG/PNG/JPEG → native save dialog appears (Chrome/Edge)
- [ ] Export in Firefox → fallback download works, browser save dialog appears
- [ ] Second export in same session → dialog opens in same directory (Chrome/Edge)
- [ ] Cancel save dialog → no error, nothing downloaded

Closes #19, closes #24