### PR TITLE
chore: add eslint-plugin-security and enable no-non-null-assertion (#51)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,10 +1,13 @@
 // @ts-check
 import withNuxt from "./.nuxt/eslint.config.mjs";
+// @ts-expect-error — no type declarations published for this package
+import security from "eslint-plugin-security";
 
 export default withNuxt(
   {
     ignores: [".claude/**"],
   },
+  security.configs.recommended,
   {
     rules: {
       // Enforce Number.* static methods over global equivalents
@@ -14,6 +17,9 @@ export default withNuxt(
         { name: "parseInt", message: "Use Number.parseInt() instead." },
         { name: "parseFloat", message: "Use Number.parseFloat() instead." },
       ],
+
+      // Match Codacy: flag non-null assertions (Nuxt disables this by default)
+      "@typescript-eslint/no-non-null-assertion": "warn",
     },
   },
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@nuxt/test-utils": "^3.23.0",
         "@vitest/coverage-v8": "^3.2.4",
         "@vue/test-utils": "^2.4.6",
+        "eslint-plugin-security": "^4.0.0",
         "happy-dom": "20.0.2",
         "vitest": "^3.2.4"
       }
@@ -7687,6 +7688,22 @@
         "eslint": ">=9.38.0"
       }
     },
+    "node_modules/eslint-plugin-security": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-4.0.0.tgz",
+      "integrity": "sha512-tfuQT8K/Li1ZxhFzyD8wPIKtlzZxqBcPr9q0jFMQ77wWAbKBVEhaMPVQRTMTvCMUDhwBe5vPVqQPwAGk/ASfxQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-regex": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/eslint-plugin-unicorn": {
       "version": "62.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-62.0.0.tgz",
@@ -11823,6 +11840,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@nuxt/test-utils": "^3.23.0",
     "@vitest/coverage-v8": "^3.2.4",
     "@vue/test-utils": "^2.4.6",
+    "eslint-plugin-security": "^4.0.0",
     "happy-dom": "20.0.2",
     "vitest": "^3.2.4"
   }


### PR DESCRIPTION
## Summary
- Install `eslint-plugin-security` with its recommended config to catch Object Injection Sink warnings locally
- Enable `@typescript-eslint/no-non-null-assertion` as `warn` (Nuxt disables it by default)
- Both rules match what Codacy enforces in CI, so `npx eslint .` now catches the same issues pre-commit

## Changed files
- **`eslint.config.mjs`** — Added security plugin config + no-non-null-assertion rule
- **`package.json`** / **`package-lock.json`** — Added `eslint-plugin-security` devDependency

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] 356 tests passing
- [x] `npm run build` passes
- [x] `npx eslint .` runs with new rules (188 pre-existing warnings across codebase, 0 errors)

Closes #51