### PR TITLE
feat: add sample machines library with menu bar (#18)

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -431,6 +431,91 @@ body {
 }
 
 /* ========================================
+   Menu Bar
+   ======================================== */
+
+.menu-bar {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin-left: 16px;
+}
+
+.menu-bar-trigger {
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.menu-bar-trigger-open {
+  color: var(--color-text-primary);
+  background: var(--color-panel-border);
+}
+
+.menu-bar-dropdown {
+  position: fixed;
+  z-index: 100;
+  background: var(--color-panel-bg);
+  border: 1px solid var(--color-input-border);
+  border-radius: 6px;
+  padding: 4px 0;
+  box-shadow: var(--shadow-md);
+  min-width: 120px;
+}
+
+.menu-bar-group-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  cursor: default;
+  user-select: none;
+}
+
+.menu-bar-group-label:hover {
+  background: var(--color-panel-border);
+}
+
+.menu-bar-submenu {
+  position: fixed;
+  z-index: 101;
+  background: var(--color-panel-bg);
+  border: 1px solid var(--color-input-border);
+  border-radius: 6px;
+  padding: 4px 0;
+  box-shadow: var(--shadow-md);
+  min-width: 240px;
+}
+
+.menu-bar-submenu-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 6px 12px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.menu-bar-submenu-item:hover {
+  background: var(--color-panel-border);
+}
+
+.menu-bar-item-name {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-primary);
+}
+
+.menu-bar-item-desc {
+  font-size: 11px;
+  font-family: var(--font-mono), monospace;
+  color: var(--color-text-secondary);
+}
+
+/* ========================================
    SVG Canvas
    ======================================== */
 

--- a/components/ui/AppHeader.vue
+++ b/components/ui/AppHeader.vue
@@ -5,6 +5,13 @@
         Automata Builder
       </h1>
       <span class="app-badge">{{ automaton.type }}</span>
+      <MenuBar>
+        <MenuBarMenu
+          label="Samples"
+          :groups="sampleGroups"
+          @select="onSelectSample"
+        />
+      </MenuBar>
     </div>
 
     <div class="header-actions">
@@ -131,6 +138,8 @@ import { useSelectionStore } from "~/stores/selection";
 import { useSimulationStore } from "~/stores/simulation";
 import { useViewportStore } from "~/stores/viewport";
 import { exportSvgBlob, exportRasterBlob, saveBlob } from "~/utils/export";
+import { SAMPLES, samplesByCategory } from "~/data/samples";
+import type { MenuGroup } from "~/components/ui/MenuBarMenu.vue";
 import type { AutomatonExport } from "~/types/automaton";
 
 const automaton = useAutomatonStore();
@@ -150,6 +159,31 @@ const dropdownStyle = computed(() => {
     left: `${rect.left}px`,
   };
 });
+
+const sampleGroups = computed<MenuGroup[]>(() => {
+  const groups: MenuGroup[] = [];
+  for (const [category, entries] of samplesByCategory()) {
+    groups.push({
+      label: category,
+      items: entries.map(e => ({ id: e.id, name: e.name, description: e.description })),
+    });
+  }
+  return groups;
+});
+
+function onSelectSample(id: string) {
+  const sample = SAMPLES.find(s => s.id === id);
+  if (!sample) return;
+
+  const hasContent = automaton.states.length > 0;
+  if (hasContent && !globalThis.confirm("This will replace the current automaton. Continue?")) {
+    return;
+  }
+
+  selection.clearSelection();
+  simulation.setInput("");
+  automaton.buildFromTuple(sample.tuple);
+}
 
 function sanitizedName(): string {
   return automaton.name.replaceAll(/\s+/g, "_");

--- a/components/ui/MenuBar.vue
+++ b/components/ui/MenuBar.vue
@@ -1,0 +1,5 @@
+<template>
+  <nav class="menu-bar">
+    <slot />
+  </nav>
+</template>

--- a/components/ui/MenuBarMenu.vue
+++ b/components/ui/MenuBarMenu.vue
@@ -1,0 +1,199 @@
+<template>
+  <div class="menu-bar-menu">
+    <button
+      ref="triggerRef"
+      :class="['btn', 'btn-ghost', 'menu-bar-trigger', { 'menu-bar-trigger-open': open }]"
+      @click="toggle"
+    >
+      {{ label }}
+    </button>
+
+    <div
+      v-if="open"
+      class="tuple-dropdown-backdrop"
+      @click="closeAll"
+    />
+
+    <div
+      v-if="open"
+      class="menu-bar-dropdown"
+      :style="dropdownStyle"
+    >
+      <div
+        v-for="(group, gi) in groups"
+        :key="gi"
+        class="menu-bar-group-label"
+        @pointerenter="onGroupEnter(gi, $event)"
+        @pointerleave="onGroupLeave"
+      >
+        <span>{{ group.label }}</span>
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 10 10"
+          fill="none"
+        >
+          <path
+            d="M3.5 2L7 5L3.5 8"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </div>
+    </div>
+
+    <div
+      v-if="open && activeGroup !== null"
+      class="menu-bar-submenu"
+      :style="submenuStyle"
+      @pointerenter="onSubmenuEnter"
+      @pointerleave="onGroupLeave"
+    >
+      <div
+        v-for="item in groups[activeGroup].items"
+        :key="item.id"
+        class="menu-bar-submenu-item"
+        @click="onItemClick(item.id)"
+      >
+        <span class="menu-bar-item-name">{{ item.name }}</span>
+        <span class="menu-bar-item-desc">{{ item.description }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+/** A single selectable item within a menu group. */
+export interface MenuItem {
+  /** Unique identifier emitted on selection. */
+  id: string;
+  /** Display name shown in the submenu. */
+  name: string;
+  /** Secondary description (e.g. formal language notation). */
+  description: string;
+}
+
+/** A group of related menu items with a shared label. */
+export interface MenuGroup {
+  /** Group header text shown in the dropdown. */
+  label: string;
+  /** Items in this group. */
+  items: MenuItem[];
+}
+
+defineProps<{
+  /** Trigger button text. */
+  label: string;
+  /** Grouped items to display. */
+  groups: MenuGroup[];
+}>();
+
+const emit = defineEmits<{
+  select: [itemId: string];
+}>();
+
+const triggerRef = ref<HTMLButtonElement | null>(null);
+const open = ref(false);
+const activeGroup = ref<number | null>(null);
+
+/** Timer ID for the 100ms hover delay. */
+let hoverTimer: ReturnType<typeof setTimeout> | null = null;
+
+/** Pixel position of the dropdown (below trigger). */
+const dropdownPos = ref({ top: 0, left: 0 });
+
+/** Pixel position of the hovered group row (for submenu alignment). */
+const groupRowTop = ref(0);
+
+/** Right edge of the dropdown (for submenu left position). */
+const dropdownRight = ref(0);
+
+const dropdownStyle = computed(() => ({
+  top: `${dropdownPos.value.top}px`,
+  left: `${dropdownPos.value.left}px`,
+}));
+
+const submenuStyle = computed(() => ({
+  top: `${groupRowTop.value}px`,
+  left: `${dropdownRight.value}px`,
+}));
+
+function toggle() {
+  if (open.value) {
+    closeAll();
+  }
+  else {
+    openDropdown();
+  }
+}
+
+function openDropdown() {
+  if (!triggerRef.value) return;
+  const rect = triggerRef.value.getBoundingClientRect();
+  dropdownPos.value = { top: rect.bottom + 4, left: rect.left };
+  open.value = true;
+  activeGroup.value = null;
+}
+
+function closeAll() {
+  clearTimer();
+  open.value = false;
+  activeGroup.value = null;
+}
+
+function clearTimer() {
+  if (hoverTimer !== null) {
+    clearTimeout(hoverTimer);
+    hoverTimer = null;
+  }
+}
+
+function onGroupEnter(index: number, event: PointerEvent) {
+  clearTimer();
+  activeGroup.value = index;
+
+  const target = event.currentTarget as HTMLElement;
+  const rowRect = target.getBoundingClientRect();
+  groupRowTop.value = rowRect.top;
+
+  const parent = target.parentElement;
+  if (parent) {
+    const parentRect = parent.getBoundingClientRect();
+    dropdownRight.value = parentRect.right;
+  }
+}
+
+function onGroupLeave() {
+  clearTimer();
+  hoverTimer = setTimeout(() => {
+    activeGroup.value = null;
+  }, 100);
+}
+
+function onSubmenuEnter() {
+  clearTimer();
+}
+
+function onItemClick(itemId: string) {
+  emit("select", itemId);
+  closeAll();
+}
+
+// Close on Escape key at the document level
+function onKeydown(event: KeyboardEvent) {
+  if (event.key === "Escape" && open.value) {
+    closeAll();
+  }
+}
+
+onMounted(() => {
+  document.addEventListener("keydown", onKeydown);
+});
+
+onUnmounted(() => {
+  document.removeEventListener("keydown", onKeydown);
+  clearTimer();
+});
+</script>

--- a/data/__tests__/samples.test.ts
+++ b/data/__tests__/samples.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { AutomatonType, EPSILON } from "~/types/automaton";
+import { SAMPLES, SampleCategory, samplesByCategory } from "../samples";
+
+describe("data/samples", () => {
+  describe("unique IDs", () => {
+    it("every sample has a unique id", () => {
+      const ids = SAMPLES.map(s => s.id);
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+  });
+
+  describe("tuple integrity", () => {
+    for (const sample of SAMPLES) {
+      describe(sample.id, () => {
+        it("start state exists in states array", () => {
+          expect(sample.tuple.states).toContain(sample.tuple.startState);
+        });
+
+        it("all accept states exist in states array", () => {
+          for (const acc of sample.tuple.acceptStates) {
+            expect(sample.tuple.states).toContain(acc);
+          }
+        });
+
+        it("transition sources are valid states", () => {
+          for (const source of Object.keys(sample.tuple.transitions)) {
+            expect(sample.tuple.states).toContain(source);
+          }
+        });
+
+        it("transition targets are valid states", () => {
+          for (const symbolMap of Object.values(sample.tuple.transitions)) {
+            for (const targets of Object.values(symbolMap)) {
+              for (const target of targets) {
+                expect(sample.tuple.states).toContain(target);
+              }
+            }
+          }
+        });
+
+        it("transition symbols are in alphabet or EPSILON", () => {
+          const validSymbols = new Set([...sample.tuple.alphabet, EPSILON]);
+          for (const symbolMap of Object.values(sample.tuple.transitions)) {
+            for (const symbol of Object.keys(symbolMap)) {
+              expect(validSymbols).toContain(symbol);
+            }
+          }
+        });
+      });
+    }
+  });
+
+  describe("category constraints", () => {
+    it("DFA samples have AutomatonType.DFA", () => {
+      const dfaSamples = SAMPLES.filter(s => s.category === SampleCategory.DFA);
+      for (const sample of dfaSamples) {
+        expect(sample.tuple.type).toBe(AutomatonType.DFA);
+      }
+    });
+
+    it("NFA samples have AutomatonType.NFA", () => {
+      const nfaSamples = SAMPLES.filter(s => s.category === SampleCategory.NFA);
+      for (const sample of nfaSamples) {
+        expect(sample.tuple.type).toBe(AutomatonType.NFA);
+      }
+    });
+
+    it("NFA-ε samples have at least one epsilon transition", () => {
+      const epsSamples = SAMPLES.filter(s => s.category === SampleCategory.NFAEpsilon);
+      expect(epsSamples.length).toBeGreaterThan(0);
+
+      for (const sample of epsSamples) {
+        const hasEpsilon = Object.values(sample.tuple.transitions).some(
+          symbolMap => EPSILON in symbolMap,
+        );
+        expect(hasEpsilon).toBe(true);
+      }
+    });
+  });
+
+  describe("samplesByCategory()", () => {
+    it("covers all samples", () => {
+      const map = samplesByCategory();
+      let total = 0;
+      for (const entries of map.values()) {
+        total += entries.length;
+      }
+      expect(total).toBe(SAMPLES.length);
+    });
+
+    it("groups match sample categories", () => {
+      const map = samplesByCategory();
+      for (const [category, entries] of map) {
+        for (const entry of entries) {
+          expect(entry.category).toBe(category);
+        }
+      }
+    });
+  });
+});

--- a/data/samples.ts
+++ b/data/samples.ts
@@ -1,0 +1,274 @@
+import type { TupleData } from "~/stores/automaton";
+import { AutomatonType, EPSILON } from "~/types/automaton";
+
+/** Categories for organizing sample machines in the menu. */
+export enum SampleCategory {
+  DFA = "DFA",
+  NFA = "NFA",
+  NFAEpsilon = "NFA-ε",
+  Advanced = "Advanced",
+}
+
+/** A single sample machine entry with metadata and tuple data. */
+export interface SampleEntry {
+  /** Unique identifier for this sample. */
+  id: string;
+  /** Display name shown in the menu. */
+  name: string;
+  /** Formal language description using set notation. */
+  description: string;
+  /** Category for grouping in the menu. */
+  category: SampleCategory;
+  /** Full 5-tuple definition, ready for buildFromTuple(). */
+  tuple: TupleData;
+}
+
+/** All available sample machines. */
+export const SAMPLES: SampleEntry[] = [
+  // ── DFA ────────────────────────────────────────
+  {
+    id: "dfa-ends-01",
+    name: "Strings ending in 01",
+    description: "L = { w ∈ {0,1}* | w ends with 01 }",
+    category: SampleCategory.DFA,
+    tuple: {
+      name: "Strings ending in 01",
+      type: AutomatonType.DFA,
+      states: ["q0", "q1", "q2"],
+      alphabet: ["0", "1"],
+      startState: "q0",
+      acceptStates: ["q2"],
+      transitions: {
+        q0: { 0: ["q1"], 1: ["q0"] },
+        q1: { 0: ["q1"], 1: ["q2"] },
+        q2: { 0: ["q1"], 1: ["q0"] },
+      },
+    },
+  },
+  {
+    id: "dfa-even-zeros",
+    name: "Even number of 0s",
+    description: "L = { w ∈ {0,1}* | w has an even number of 0s }",
+    category: SampleCategory.DFA,
+    tuple: {
+      name: "Even number of 0s",
+      type: AutomatonType.DFA,
+      states: ["q0", "q1"],
+      alphabet: ["0", "1"],
+      startState: "q0",
+      acceptStates: ["q0"],
+      transitions: {
+        q0: { 0: ["q1"], 1: ["q0"] },
+        q1: { 0: ["q0"], 1: ["q1"] },
+      },
+    },
+  },
+  {
+    id: "dfa-divisible-by-3",
+    name: "Divisible by 3",
+    description: "L = { w ∈ {0,1}* | binary value of w ≡ 0 (mod 3) }",
+    category: SampleCategory.DFA,
+    tuple: {
+      name: "Divisible by 3",
+      type: AutomatonType.DFA,
+      states: ["q0", "q1", "q2"],
+      alphabet: ["0", "1"],
+      startState: "q0",
+      acceptStates: ["q0"],
+      transitions: {
+        q0: { 0: ["q0"], 1: ["q1"] },
+        q1: { 0: ["q2"], 1: ["q0"] },
+        q2: { 0: ["q1"], 1: ["q2"] },
+      },
+    },
+  },
+
+  // ── NFA ────────────────────────────────────────
+  {
+    id: "nfa-contains-101",
+    name: "Contains 101",
+    description: "L = { w ∈ {0,1}* | w contains 101 as a substring }",
+    category: SampleCategory.NFA,
+    tuple: {
+      name: "Contains 101",
+      type: AutomatonType.NFA,
+      states: ["q0", "q1", "q2", "q3"],
+      alphabet: ["0", "1"],
+      startState: "q0",
+      acceptStates: ["q3"],
+      transitions: {
+        q0: { 0: ["q0"], 1: ["q0", "q1"] },
+        q1: { 0: ["q2"] },
+        q2: { 1: ["q3"] },
+        q3: { 0: ["q3"], 1: ["q3"] },
+      },
+    },
+  },
+  {
+    id: "nfa-third-from-last-1",
+    name: "Third-from-last is 1",
+    description: "L = { w ∈ {0,1}* | the third symbol from the end is 1 }",
+    category: SampleCategory.NFA,
+    tuple: {
+      name: "Third-from-last is 1",
+      type: AutomatonType.NFA,
+      states: ["q0", "q1", "q2", "q3"],
+      alphabet: ["0", "1"],
+      startState: "q0",
+      acceptStates: ["q3"],
+      transitions: {
+        q0: { 0: ["q0"], 1: ["q0", "q1"] },
+        q1: { 0: ["q2"], 1: ["q2"] },
+        q2: { 0: ["q3"], 1: ["q3"] },
+      },
+    },
+  },
+
+  // ── NFA-ε ──────────────────────────────────────
+  {
+    id: "nfa-eps-union",
+    name: "Union via ε-bridges",
+    description: "L = { w ∈ {a,b}* | w = aⁿ or w = bⁿ, n ≥ 1 }",
+    category: SampleCategory.NFAEpsilon,
+    tuple: {
+      name: "Union via ε-bridges",
+      type: AutomatonType.NFA,
+      states: ["q0", "q1", "q2", "q3", "q4"],
+      alphabet: ["a", "b"],
+      startState: "q0",
+      acceptStates: ["q2", "q4"],
+      transitions: {
+        q0: { [EPSILON]: ["q1", "q3"] },
+        q1: { a: ["q1", "q2"] },
+        q2: {},
+        q3: { b: ["q3", "q4"] },
+        q4: {},
+      },
+    },
+  },
+  {
+    id: "nfa-eps-optional-prefix",
+    name: "Optional prefix skip",
+    description: "L = { w ∈ {0,1}* | w = 0*1 or w = 1 }",
+    category: SampleCategory.NFAEpsilon,
+    tuple: {
+      name: "Optional prefix skip",
+      type: AutomatonType.NFA,
+      states: ["q0", "q1", "q2"],
+      alphabet: ["0", "1"],
+      startState: "q0",
+      acceptStates: ["q2"],
+      transitions: {
+        q0: { 0: ["q0"], [EPSILON]: ["q1"] },
+        q1: { 1: ["q2"] },
+        q2: {},
+      },
+    },
+  },
+
+  // ── Advanced ───────────────────────────────────
+  {
+    id: "adv-even-0s-and-1s",
+    name: "Even 0s and even 1s",
+    description: "L = { w ∈ {0,1}* | w has even 0s and even 1s }",
+    category: SampleCategory.Advanced,
+    tuple: {
+      name: "Even 0s and even 1s",
+      type: AutomatonType.DFA,
+      states: ["q0", "q1", "q2", "q3"],
+      alphabet: ["0", "1"],
+      startState: "q0",
+      acceptStates: ["q0"],
+      transitions: {
+        q0: { 0: ["q1"], 1: ["q2"] },
+        q1: { 0: ["q0"], 1: ["q3"] },
+        q2: { 0: ["q3"], 1: ["q0"] },
+        q3: { 0: ["q2"], 1: ["q1"] },
+      },
+    },
+  },
+  {
+    id: "adv-divisible-by-5",
+    name: "Divisible by 5",
+    description: "L = { w ∈ {0,1}* | binary value of w ≡ 0 (mod 5) }",
+    category: SampleCategory.Advanced,
+    tuple: {
+      name: "Divisible by 5",
+      type: AutomatonType.DFA,
+      states: ["q0", "q1", "q2", "q3", "q4"],
+      alphabet: ["0", "1"],
+      startState: "q0",
+      acceptStates: ["q0"],
+      transitions: {
+        q0: { 0: ["q0"], 1: ["q1"] },
+        q1: { 0: ["q2"], 1: ["q3"] },
+        q2: { 0: ["q4"], 1: ["q0"] },
+        q3: { 0: ["q1"], 1: ["q2"] },
+        q4: { 0: ["q3"], 1: ["q4"] },
+      },
+    },
+  },
+  {
+    id: "adv-same-start-end",
+    name: "Starts and ends with same symbol",
+    description: "L = { w ∈ {0,1}⁺ | first and last symbols are equal }",
+    category: SampleCategory.Advanced,
+    tuple: {
+      name: "Starts and ends with same symbol",
+      type: AutomatonType.NFA,
+      states: ["q0", "q1", "q2", "q3", "q4"],
+      alphabet: ["0", "1"],
+      startState: "q0",
+      acceptStates: ["q2", "q4"],
+      transitions: {
+        q0: { 0: ["q1", "q2"], 1: ["q3", "q4"] },
+        q1: { 0: ["q1", "q2"], 1: ["q1"] },
+        q2: {},
+        q3: { 0: ["q3"], 1: ["q3", "q4"] },
+        q4: {},
+      },
+    },
+  },
+  {
+    id: "adv-concat-epsilon",
+    name: "Concatenation via ε",
+    description: "L = { w ∈ {0,1}* | w ∈ 0*1 ∪ 1*0 }",
+    category: SampleCategory.Advanced,
+    tuple: {
+      name: "Concatenation via ε",
+      type: AutomatonType.NFA,
+      states: ["q0", "q1", "q2", "q3", "q4", "q5"],
+      alphabet: ["0", "1"],
+      startState: "q0",
+      acceptStates: ["q5"],
+      transitions: {
+        q0: { [EPSILON]: ["q1", "q3"] },
+        q1: { 0: ["q1"], 1: ["q2"] },
+        q2: { [EPSILON]: ["q5"] },
+        q3: { 1: ["q3"], 0: ["q4"] },
+        q4: { [EPSILON]: ["q5"] },
+        q5: {},
+      },
+    },
+  },
+];
+
+/**
+ * Group all samples by their category.
+ *
+ * @returns Map from SampleCategory to the samples in that category,
+ *          preserving insertion order from the SAMPLES array.
+ */
+export function samplesByCategory(): Map<SampleCategory, SampleEntry[]> {
+  const map = new Map<SampleCategory, SampleEntry[]>();
+  for (const sample of SAMPLES) {
+    const list = map.get(sample.category);
+    if (list) {
+      list.push(sample);
+    }
+    else {
+      map.set(sample.category, [sample]);
+    }
+  }
+  return map;
+}


### PR DESCRIPTION
## Summary
- Add 11 pre-built sample automata (3 DFA, 2 NFA, 2 NFA-ε, 4 Advanced) with formal language descriptions
- Add reusable menu bar system (`MenuBar` + `MenuBarMenu`) with dropdown and submenu flyout
- Integrate Samples menu in the app header — click to load a sample, with confirmation if canvas is non-empty

## New Files
- `data/samples.ts` — Sample data with `SampleCategory` enum, `SampleEntry` interface, `samplesByCategory()` helper
- `data/__tests__/samples.test.ts` — Data integrity tests (unique IDs, valid tuples, category constraints)
- `components/ui/MenuBar.vue` — Slot-based nav container for future menus
- `components/ui/MenuBarMenu.vue` — Interactive menu with grouped dropdown + submenu flyout (100ms hover delay)

## Modified Files
- `assets/css/main.css` — Menu Bar CSS section
- `components/ui/AppHeader.vue` — MenuBar integration with sample selection handler

## Test plan
- [ ] Click "Samples" → dropdown shows 4 category headers (DFA, NFA, NFA-ε, Advanced)
- [ ] Hover category → submenu flyout with machine names and formal descriptions
- [ ] Click a sample on empty canvas → automaton loads with auto-layout
- [ ] Click a sample with existing content → confirm dialog appears
- [ ] Press Escape or click backdrop → menu closes
- [ ] Verify dark mode styling
- [ ] All 417 tests pass, type-check clean, lint clean

Closes #18